### PR TITLE
Update getModules() to work with Kicad 6.0

### DIFF
--- a/hide_references/hide_references_action.py
+++ b/hide_references/hide_references_action.py
@@ -9,6 +9,12 @@ class HideReferencesAction(pcbnew.ActionPlugin):
 
     def Run(self):
         # The entry function of the plugin that is executed on user action
-        pcb = pcbnew.GetBoard()
-        for module in pcb.GetModules():
+        pcb = pcbnew.GetBoard()       
+        
+        if hasattr(pcb, 'GetModules'):
+            modules = pcb.GetModules()
+        else:
+            modules = pcb.GetFootprints()
+
+        for module in modules:
             module.Reference().SetVisible(False)


### PR DESCRIPTION
Avoids the following error in Kicad 6.0
![image](https://user-images.githubusercontent.com/3289118/148472222-8f743802-cfae-46af-a1a6-38f09c0481d1.png)

I have not tested if it breaks on previous versions.